### PR TITLE
Search-282: Can't navigate through Search drop down using keyboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphony-react-autosuggest",
-  "version": "3.7.3-symphony.2",
+  "version": "3.7.3-symphony.3",
   "description": "WAI-ARIA compliant React autosuggest component",
   "main": "dist/index.js",
   "repository": {

--- a/src/AutosuggestContainer.js
+++ b/src/AutosuggestContainer.js
@@ -99,9 +99,6 @@ export default class AutosuggestContainer extends Component {
     const initialState = {
       isFocused: false,
       isCollapsed: true,
-      focusedSectionIndex: null,
-      focusedSuggestionIndex: null,
-      valueBeforeUpDown: null,
       lastAction: null
     };
 

--- a/src/reducerAndActions.js
+++ b/src/reducerAndActions.js
@@ -1,7 +1,6 @@
 const INPUT_FOCUSED = 'INPUT_FOCUSED';
 const INPUT_BLURRED = 'INPUT_BLURRED';
 const INPUT_CHANGED = 'INPUT_CHANGED';
-const UPDATE_FOCUSED_SUGGESTION = 'UPDATE_FOCUSED_SUGGESTION';
 const REVEAL_SUGGESTIONS = 'REVEAL_SUGGESTIONS';
 const CLOSE_SUGGESTIONS = 'CLOSE_SUGGESTIONS';
 
@@ -23,15 +22,6 @@ export function inputChanged(shouldRenderSuggestions, lastAction) {
     type: INPUT_CHANGED,
     shouldRenderSuggestions,
     lastAction
-  };
-}
-
-export function updateFocusedSuggestion(sectionIndex, suggestionIndex, value) {
-  return {
-    type: UPDATE_FOCUSED_SUGGESTION,
-    sectionIndex,
-    suggestionIndex,
-    value
   };
 }
 
@@ -61,36 +51,15 @@ export default function reducer(state, action) {
       return {
         ...state,
         isFocused: false,
-        focusedSectionIndex: null,
-        focusedSuggestionIndex: null,
-        valueBeforeUpDown: null,
         isCollapsed: true
       };
 
     case INPUT_CHANGED:
       return {
         ...state,
-        focusedSectionIndex: null,
-        focusedSuggestionIndex: null,
-        valueBeforeUpDown: null,
         isCollapsed: !action.shouldRenderSuggestions,
         lastAction: action.lastAction
       };
-
-    case UPDATE_FOCUSED_SUGGESTION: {
-      const { value, sectionIndex, suggestionIndex } = action;
-      const valueBeforeUpDown =
-        state.valueBeforeUpDown === null && typeof value !== 'undefined'
-          ? value
-          : state.valueBeforeUpDown;
-
-      return {
-        ...state,
-        focusedSectionIndex: sectionIndex,
-        focusedSuggestionIndex: suggestionIndex,
-        valueBeforeUpDown
-      };
-    }
 
     case REVEAL_SUGGESTIONS:
       return {
@@ -101,9 +70,6 @@ export default function reducer(state, action) {
     case CLOSE_SUGGESTIONS:
       return {
         ...state,
-        focusedSectionIndex: null,
-        focusedSuggestionIndex: null,
-        valueBeforeUpDown: null,
         isCollapsed: true,
         lastAction: action.lastAction
       };


### PR DESCRIPTION
## Description
Fixes a long standing issue where keyboard navigation with up and down arrow keys was unusable with the header search.


## Approach
How does this change address the problem?
- #### Problem with the code: With the upgrade to a newer version of redux and its libraries, suspicion is, it broke how this component was trying to store and update the "focusedSectionIndex", "focusedSuggestionIndex" data from its own redux state. The redux state was never updated consistently for the component to re-render resulting in a cyclic failure to ever update that set of data and hence always sitting at "null" and never resulting in the indexes updating.

- #### Fix: Changes where the data is stored from the component's own redux store to the component's state. The following have been done to accommodate this:

1. Stores and retrieves "focusedSectionIndex", "focusedSuggestionIndex" and "valueBeforeUpDown" in the component's state rather than in the redux state.
2. Removes the associated data from the redux state.
3. Defines a local method in the Autosuggest component to handle the updates of keydown events for up and down arrows, mouse enter and mouse exit events, input blur event.
4. Removes the redux related code to update the above mentioned data.
5. Sends a boolean of whether a section or item index is selected to the onKeyDown method to prevent opening the advanced search module when the user selects a room or person from the header search dropdown after selecting an operator.


## Related PRs
SFE-Client-App -> https://github.com/SymphonyOSF/SFE-Client-App/pull/7419