### PR TITLE
Search-437: Fixes the issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphony-react-autosuggest",
-  "version": "3.7.3-symphony.3",
+  "version": "3.7.3-symphony.5",
   "description": "WAI-ARIA compliant React autosuggest component",
   "main": "dist/index.js",
   "repository": {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -289,6 +289,7 @@ class Autosuggest extends Component {
     };
     const onMouseDown = () => {
       this.justClickedOnSuggestion = true;
+      this.updateFocusedSuggestion(null, null);
     };
     const onClick = event => {
       const { sectionIndex, suggestionIndex } =


### PR DESCRIPTION
## Problem
We were not resetting the focused item and section indexes when the mouse down event occurred. This resulted in the selection of an operator when hitting the enter key for advanced search.

## Solution
Reset the focused section and item indexes on mouse down event.