### PR TITLE
Search-473: made the second option in the drop-down the default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphony-react-autosuggest",
-  "version": "3.7.3-symphony.5",
+  "version": "3.7.3-symphony.6",
   "description": "WAI-ARIA compliant React autosuggest component",
   "main": "dist/index.js",
   "repository": {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -184,6 +184,7 @@ class Autosuggest extends Component {
     const items = (isOpen ? suggestions : []);
     const maybeCloseSuggestions = (method, cb, shouldCloseSuggestions) => {
       var isValid = false;
+
       if (shouldHideSuggestions(method) && (shouldCloseSuggestions === undefined || shouldCloseSuggestions)) {
         isValid = true;
       }
@@ -239,7 +240,20 @@ class Autosuggest extends Component {
                 valueBeforeUpDown :
                 this.getSuggestionValueByIndex(newFocusedSectionIndex, newFocusedItemIndex);
 
-              this.updateFocusedSuggestion(newFocusedSectionIndex, newFocusedItemIndex, value);
+              var updatedFocusedItemIndex = newFocusedItemIndex,
+                updatedFocusedSectionIndex = newFocusedSectionIndex;
+
+              if (newFocusedSectionIndex === 0 && newFocusedItemIndex === 0) {
+                if (event.key === 'ArrowDown') {
+                  updatedFocusedItemIndex = 1;
+                  updatedFocusedSectionIndex = 0;
+                }
+                if (event.key === 'ArrowUp') {
+                  updatedFocusedItemIndex = null;
+                  updatedFocusedSectionIndex = null;
+                }
+              }
+              this.updateFocusedSuggestion(updatedFocusedSectionIndex, updatedFocusedItemIndex, value);
               this.maybeCallOnChange(event, newValue, event.key === 'ArrowDown' ? 'down' : 'up');
             }
             event.preventDefault();


### PR DESCRIPTION
1. Made the highlighter go to the second option by default when down arrow is pressed. This is done because the first section is always an unselectable/unclickable header
2. Bumped up the version

This PR handles the first part of [Search-473](https://perzoinc.atlassian.net/browse/SEARCH-473). The other parts are handled in [SFE-Client-App-7625](https://github.com/SymphonyOSF/SFE-Client-App/pull/7625)