### PR TITLE
Search-577: "Recent Searches" should not be a link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphony-react-autosuggest",
-  "version": "3.7.3-symphony.7",
+  "version": "3.7.3-symphony.8",
   "description": "WAI-ARIA compliant React autosuggest component",
   "main": "dist/index.js",
   "repository": {


### PR DESCRIPTION
## Description
Removes a previous hack that was used to skip focusing the first item in the dropdown. Adds a generic prop that can be passed down from any component that uses this to skip focusing any suggestion item on keydown and mouse enter events as required.
[JIRA-Ticket](https://perzoinc.atlassian.net/browse/SEARCH-577)


## Approach
Instead of checking if the data that is being is received from the header search component and the first item in the dropdown, we check for the prop "shouldFocusSuggestion" that is passed down as a boolean.
#### Problem with the code:
 - Code was rigid to handle only a specific scenario
#### Fix:
 - Made it flexible enough to handle multiple scenarios


## Learning
N/A


#### Blog Posts
N/A


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_dev | [Search-577](https://github.com/SymphonyOSF/SFE-Client-App/pull/8181)


## Open Questions if any and Todos
- [x] Documentation (Added necessary comments)