### PR TITLE
SEARCH-732 (Shows error message when tried to select In operator through drop down)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphony-react-autosuggest",
-  "version": "3.7.3-symphony.8",
+  "version": "3.7.3-symphony.9",
   "description": "WAI-ARIA compliant React autosuggest component",
   "main": "dist/index.js",
   "repository": {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -291,6 +291,11 @@ class Autosuggest extends Component {
             break;
           }
 
+          case 'Tab': {
+            this.updateFocusedSuggestion(null, null);
+            break;
+          }
+
           case 'Escape':
             if (isOpen) {
               // If input.type === 'search', the browser clears the input


### PR DESCRIPTION
## Description
Shows error message when tried to select In operator through drop down

## Before
![before](https://user-images.githubusercontent.com/596478/39695146-3a5f8282-5207-11e8-95f9-dffd19b39cf5.gif)

## After
![after](https://user-images.githubusercontent.com/596478/39695153-4308aecc-5207-11e8-817b-0ec1e5d19541.gif)


**Approach**

How does this change address the problem?
- #### Problem with the code:  Pressing Tab for selecting operator was not clearing the suggestion list index.
![screen shot 2018-05-07 at 2 41 48 pm](https://user-images.githubusercontent.com/596478/39694394-d0391bc2-5204-11e8-93e3-e6d1af8e89fb.png)

- #### Fix:  Added a Tab event to clear the suggestion list index.

@NitinSingh2020  @lsouza-daitan @filipecastro @VikasShashidhar @astanzani Please Review. Thanks 😃 