### PR TITLE
SEARCH-1298 Allows to use ref on the connected Autosuggest component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphony-react-autosuggest",
-  "version": "3.7.3-symphony.9",
+  "version": "3.7.3-symphony.10",
   "description": "WAI-ARIA compliant React autosuggest component",
   "main": "dist/index.js",
   "repository": {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -404,4 +404,4 @@ class Autosuggest extends Component {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Autosuggest);
+export default connect(mapStateToProps, mapDispatchToProps, null, { withRef: true })(Autosuggest);

--- a/src/AutosuggestContainer.js
+++ b/src/AutosuggestContainer.js
@@ -71,6 +71,7 @@ export default class AutosuggestContainer extends Component {
     getSectionSuggestions: PropTypes.func,
     focusInputOnSuggestionClick: PropTypes.bool,
     inputRef: PropTypes.func,
+    componentRef: PropTypes.func,
     theme: PropTypes.object,
     id: PropTypes.string
   };
@@ -89,6 +90,7 @@ export default class AutosuggestContainer extends Component {
     },
     focusInputOnSuggestionClick: true,
     inputRef: noop,
+    componentRef: noop,
     theme: defaultTheme,
     id: '1'
   };
@@ -136,7 +138,8 @@ export default class AutosuggestContainer extends Component {
                    theme={mapToAutowhateverTheme(theme)}
                    id={id}
                    inputRef={this.saveInput}
-                   store={this.store} />
+                   store={this.store}
+                   ref={this.props.componentRef} />
     );
   }
 }


### PR DESCRIPTION
## Description
Fixes an issue where the info barrier modal is opened on top of the header search dropdown and then it becomes impossible to close the dropdown after clicking on the modal's "Close" button. See gifs for more clarity.
[SEARCH-1298](https://perzoinc.atlassian.net/browse/SEARCH-1298)

## Earlier
![1298-before](https://user-images.githubusercontent.com/38115424/52498040-cb885180-2bbe-11e9-9b77-b14da0b718c8.gif)

## Now
![1298-after](https://user-images.githubusercontent.com/38115424/52498042-cc20e800-2bbe-11e9-9a43-f9d95e5ac303.gif)

## Approach
[comment]: # (How does this change address the problem?)
#### Problem with the code:
- After closing a modal, focus doesn't return to the element that was previously focused -- in this case, the header search dropdown.
- In `symphony-react-autosuggest`, there's a flag called `justClickedOnSuggestion` which controls whether or not the dropdown should be closed. This flag should be reset to `false` when clicking on the search dropdown, but that never happens in the bug scenario (room prompt + info barrier modal). 

#### Fix:
- Forcefully set the above-mentioned flag to `false` when the infobarrier is closed.
- Forcefully return focus to the header search when the infobarrier is closed.



## Related PRs
[comment]: # (List the related PRs against other branches.)

Repo | PR #
------ | ------ 
SFE-Client-App | https://github.com/SymphonyOSF/SFE-Client-App/pull/13517