### PR TITLE
SEARCH-1401: [Header Search] <enter> hint is misleading when another suggestion is focused

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphony-react-autosuggest",
-  "version": "3.7.3-symphony.10",
+  "version": "3.7.3-symphony.11",
   "description": "WAI-ARIA compliant React autosuggest component",
   "main": "dist/index.js",
   "repository": {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -227,6 +227,7 @@ class Autosuggest extends Component {
         this.maybeCallOnSuggestionsUpdateRequested({ value, reason: 'type' });
       },
       onKeyDown: (event, data) => {
+        var sectionType = null;
         switch (event.key) {
           case 'ArrowDown':
           case 'ArrowUp':
@@ -245,6 +246,7 @@ class Autosuggest extends Component {
 
               if (updatedFocusedItemIndex !== null && updatedFocusedSectionIndex !== null) {
                 var shouldFocusSuggestion = this.props.suggestions[updatedFocusedSectionIndex].items[updatedFocusedItemIndex].shouldFocusSuggestion;
+                sectionType = this.props.suggestions[updatedFocusedSectionIndex].type;
 
                 /* Focus a suggestion only if it is required to
                  * be. For certain section headers, skip focus.
@@ -318,7 +320,7 @@ class Autosuggest extends Component {
             break;
         }
 
-        onKeyDown && onKeyDown(event, data);
+        onKeyDown && onKeyDown(event, data, sectionType);
       }
     };
     const onMouseEnter = (event, { sectionIndex, itemIndex }) => {


### PR DESCRIPTION
## Description
Updates the accessibility text in the header search based on the section and item that the user has selected from the results
[SEARCH-1401](https://perzoinc.atlassian.net/browse/SEARCH-1401)


## Approach
[comment]: # (How does this change address the problem?)
#### Problem with the code:
- Was never implemented

#### Fix:
- Determines the section type based on the currently highlighted suggestion
- Passes on the section type on the key down event


## Learning
N/A


#### Blog Posts
N/A


## Related PRs
[comment]: # (List the related PRs against other branches.)

Repo | Branch | PR #
------ | ------ | ------
SFE-Client | SEARCH-1401 | [PR #14454](https://github.com/SymphonyOSF/SFE-Client-App/pull/14454)
SFE-Packages | SEARCH-1401 | [PR #2484](https://github.com/SymphonyOSF/SFE-Packages/pull/2484)


## Open Questions if any and Todos
[comment]: # (When resolved, check the box and explain the answer.)
- [x] Automation-Tests
- [x] Documentation
- [x] Language Translations
- [x] Unit-Tests


## Custom branch on PR builder
N/A