### PR TITLE
SEARCH-1402 Added prop for aria-describedby

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symphony-react-autosuggest",
-  "version": "3.7.3-symphony.11",
+  "version": "3.7.3-symphony.12",
   "description": "WAI-ARIA compliant React autosuggest component",
   "main": "dist/index.js",
   "repository": {

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -50,6 +50,7 @@ class Autosuggest extends Component {
     id: PropTypes.string.isRequired,
     inputRef: PropTypes.func.isRequired,
     shouldHideSuggestions: PropTypes.func.isRequired,
+    getDescriptionId: PropTypes.func.isRequired,
 
     isFocused: PropTypes.bool.isRequired,
     isCollapsed: PropTypes.bool.isRequired,
@@ -176,7 +177,7 @@ class Autosuggest extends Component {
       onSuggestionSelected, multiSection, renderSectionTitle, id,
       getSectionSuggestions, focusInputOnSuggestionClick, theme, isFocused,
       isCollapsed, inputFocused, inputBlurred, inputChanged,
-      revealSuggestions, closeSuggestions, shouldHideSuggestions
+      revealSuggestions, closeSuggestions, shouldHideSuggestions, getDescriptionId
     } = this.props;
     const { focusedSectionIndex, focusedSuggestionIndex, valueBeforeUpDown } = this.state;
     const { value, onBlur, onFocus, onKeyDown } = inputProps;
@@ -374,6 +375,7 @@ class Autosuggest extends Component {
     };
     const itemProps = ({ sectionIndex, itemIndex }) => {
       return {
+        'aria-describedby': getDescriptionId(sectionIndex, itemIndex),
         'data-section-index': sectionIndex,
         'data-suggestion-index': itemIndex,
         onMouseEnter,

--- a/src/AutosuggestContainer.js
+++ b/src/AutosuggestContainer.js
@@ -65,6 +65,7 @@ export default class AutosuggestContainer extends Component {
     },
     shouldRenderSuggestions: PropTypes.func,
     shouldHideSuggestions: PropTypes.func,
+    getDescriptionId: PropTypes.func,
     onSuggestionSelected: PropTypes.func,
     multiSection: PropTypes.bool,
     renderSectionTitle: PropTypes.func,
@@ -80,6 +81,7 @@ export default class AutosuggestContainer extends Component {
     onSuggestionsUpdateRequested: noop,
     shouldRenderSuggestions: value => value.trim().length > 0,
     shouldHideSuggestions: () => true,
+    getDescriptionId: noop,
     onSuggestionSelected: noop,
     multiSection: false,
     renderSectionTitle() {
@@ -119,13 +121,14 @@ export default class AutosuggestContainer extends Component {
       multiSection, shouldRenderSuggestions, shouldHideSuggestions, suggestions,
       onSuggestionsUpdateRequested, getSuggestionValue, renderSuggestion,
       renderSectionTitle, getSectionSuggestions, inputProps,
-      onSuggestionSelected, focusInputOnSuggestionClick, theme, id
+      onSuggestionSelected, focusInputOnSuggestionClick, theme, id, getDescriptionId
     } = this.props;
 
     return (
       <Autosuggest multiSection={multiSection}
                    shouldRenderSuggestions={shouldRenderSuggestions}
                    shouldHideSuggestions={shouldHideSuggestions}
+                   getDescriptionId={getDescriptionId}
                    suggestions={suggestions}
                    onSuggestionsUpdateRequested={onSuggestionsUpdateRequested}
                    getSuggestionValue={getSuggestionValue}


### PR DESCRIPTION
## Description
These changes are intended to help set the `aria-describedby` attribute of the suggestions rendered by `Autowhatever`.

`Autowhatever` takes a prop object called `itemProps`, which sets whatever attributes we want to have in the `<li>` elements. Therefore I'm using this prop to set the `aria-describedby` attribute with the value returned by a new optional prop called `getDescriptionId` passed to `Autosuggest`.

For more detail, see the related PR in SFE-Client-App.

## Related PRs
[comment]: # (List the related PRs against other branches.)

Repo | Branch | PR
------ | ------ | ------
SFE-Client-App | master | https://github.com/SymphonyOSF/SFE-Client-App/pull/14633
